### PR TITLE
chore: include `csharpier` in `dotnet-tools.json`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "husky"
       ],
       "rollForward": false
+    },
+    "csharpier": {
+      "version": "1.1.2",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
I don't like installing tools globally, so it would be useful if this was included in the repo by default.

The only thing that I don't know is if this would break people relying on their global version of `csharpier`; I think it should be fine, since to use a global tool you just call it `tool` and a local tool you call it with `dotnet tool`