### PR TITLE
refactor: remove 'where T: class' constraint for IOnceSaveDataMod<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ public partial class StartCrestSelectorPlugin : BaseUnityPlugin, IOnceSaveDataMo
 }
 ```
 
-Note that the stored type (`SaveData` in this case) must be a reference type; using a value type, such
-as a struct, will result in a compile-time error.
-
 When the player starts a new game - specifically at the end of GameManager.StartNewGame - DataManager
 will read the value of the OnceSaveData property, and if non-null, serialize it in the game's saves
 directory, under `Modded/OncePerSave/N/GUID.json.dat`, where N is the save slot's number and GUID the

--- a/src/IOnceSaveDataMod.cs
+++ b/src/IOnceSaveDataMod.cs
@@ -3,7 +3,6 @@ namespace Silksong.DataManager;
 /// Interface for mods that need to store some save data at the start of each new game,
 /// but don't need to change it afterwards.
 public interface IOnceSaveDataMod<T> : IOnceSaveDataMod
-    where T : class
 {
     /// The once-save data for the current file.
     /// DataManager reads and stores its value once at the start of each new game,
@@ -19,7 +18,7 @@ public interface IOnceSaveDataMod<T> : IOnceSaveDataMod
     object? IOnceSaveDataMod.UntypedOnceSaveData
     {
         get => OnceSaveData;
-        set => OnceSaveData = value == null ? null : (T)value;
+        set => OnceSaveData = value == null ? default : (T)value;
     }
 }
 


### PR DESCRIPTION
AFAIK the constraint is unnecessary, since `default` of `T?` is `null`.