### PR TITLE
test secret test job

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -189,6 +189,5 @@ jobs:
     outputs:
       has-nuget-secret: ${{ secrets.NUGET_API_KEY != '' }}
       has-thunderstore-secret: ${{ secrets.THUNDERSTORE_API_KEY != '' }}
-      has-foo: ${{ secrets.FOO != '' }}
     steps:
       - run: echo no-op


### PR DESCRIPTION
This is a "backfill" of the change I am about to add to the template to verify that it actually behaves as expected. It will make it so the skip status of nuget and thunderstore publishes is more evident by skipping the job if the secret is absent rather than skipping the last step of the job (making the job appear successful)