### PR TITLE
Cooperate with mods that disable saving

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,6 @@
     It should follow the format major.minor.patch (semantic versioning). If you publish your mod
     as a library to NuGet, this version will also be used as the package version.
     -->
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
 </Project>

--- a/src/Hooks.cs
+++ b/src/Hooks.cs
@@ -52,10 +52,17 @@ internal static class SaveDataLoadHook
     nameof(GameManager.SaveGame),
     [typeof(int), typeof(System.Action<bool>), typeof(bool), typeof(AutoSaveName)]
 )]
+[HL.HarmonyPriority(2)]
 internal static class SaveDataSaveHook
 {
-    private static void Prefix(int saveSlot, ref System.Action<bool> ogCallback)
+    private static void Prefix(int saveSlot, ref System.Action<bool> ogCallback, bool __runOriginal)
     {
+        if (!__runOriginal)
+        {
+            // If saving has been disabled by another mod, we should disable saving modded data
+            return;
+        }
+
         if (saveSlot == 0)
         {
             return;


### PR DESCRIPTION
...regardless of whether those mods *should* disable saving

### Summary of Changes

If mod X decides to disable saving through Harmony, we should also not save modded data.
I believe that compatibility with MonoMod and MonoDetour is automatic.

### Checklist

* No change is too small for a release, so pick one:
  * [x ] I have updated the package version following semantic versioning