### PR TITLE
Remove gitsubmodule from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,3 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: daily
-  - directory: /
-    package-ecosystem: gitsubmodule
-    schedule:
-      interval: daily


### PR DESCRIPTION

### Summary of Changes

Removed gitsubmodule package-ecosystem from Dependabot config. Prevent merging reorg changes

### Checklist

* No change is too small for a release, so pick one:
  * [ ] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [X] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
